### PR TITLE
Fixed player hold action

### DIFF
--- a/source/actors/player/PlayerAction.gd
+++ b/source/actors/player/PlayerAction.gd
@@ -5,6 +5,7 @@ Manages and signalize Action input events.
 """
 
 signal pressed
+signal held
 signal released
 signal handling
 
@@ -34,4 +35,5 @@ func is_holding():
 		is_holding = true
 		emit_signal("handling")
 		emit_signal("pressed")
+		emit_signal("held")
 	return is_holding

--- a/source/actors/player/PlayerCombatActor.tscn
+++ b/source/actors/player/PlayerCombatActor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=22 format=2]
 
 [ext_resource path="res://actors/player/PlayerPlatformActor.tscn" type="PackedScene" id=1]
 [ext_resource path="res://utility/Geometry2D.gd" type="Script" id=2]
@@ -10,13 +10,14 @@
 [ext_resource path="res://actors/physics/Fall.tscn" type="PackedScene" id=8]
 [ext_resource path="res://actors/physics/Dash.tscn" type="PackedScene" id=9]
 [ext_resource path="res://actors/player/PlayerAction.tscn" type="PackedScene" id=10]
-[ext_resource path="res://actors/player/ActionBuffer.tscn" type="PackedScene" id=11]
-[ext_resource path="res://actors/combat/CombatStateMachine.gd" type="Script" id=12]
-[ext_resource path="res://actors/physics/State.gd" type="Script" id=13]
-[ext_resource path="res://actors/combat/HurtBox.tscn" type="PackedScene" id=14]
-[ext_resource path="res://actors/player/PlayerStatus.gd" type="Script" id=15]
-[ext_resource path="res://actors/player/PlayerData.tres" type="Resource" id=16]
-[ext_resource path="res://actors/player/PickupArea.gd" type="Script" id=17]
+[ext_resource path="res://actors/player/PlayerHoldAction.tscn" type="PackedScene" id=11]
+[ext_resource path="res://actors/player/ActionBuffer.tscn" type="PackedScene" id=12]
+[ext_resource path="res://actors/combat/CombatStateMachine.gd" type="Script" id=13]
+[ext_resource path="res://actors/physics/State.gd" type="Script" id=14]
+[ext_resource path="res://actors/combat/HurtBox.tscn" type="PackedScene" id=15]
+[ext_resource path="res://actors/player/PlayerStatus.gd" type="Script" id=16]
+[ext_resource path="res://actors/player/PlayerData.tres" type="Resource" id=17]
+[ext_resource path="res://actors/player/PickupArea.gd" type="Script" id=18]
 
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 40, 30 )
@@ -113,34 +114,36 @@ script = ExtResource( 5 )
 [node name="AttackAction" parent="Controls" index="6" instance=ExtResource( 10 )]
 action = "attack"
 
-[node name="DefendAction" parent="Controls" index="7" instance=ExtResource( 10 )]
+[node name="AttackHoldAction" parent="Controls" index="7" instance=ExtResource( 11 )]
+
+[node name="DefendAction" parent="Controls" index="8" instance=ExtResource( 10 )]
 action = "defend"
 
-[node name="ActionBuffer" parent="Controls" index="8" instance=ExtResource( 11 )]
+[node name="ActionBuffer" parent="Controls" index="9" instance=ExtResource( 12 )]
 
 [node name="CombatStateMachine" type="Node2D" parent="." index="4"]
-script = ExtResource( 12 )
+script = ExtResource( 13 )
 
 [node name="IdleState" type="Node2D" parent="CombatStateMachine" index="0"]
-script = ExtResource( 13 )
+script = ExtResource( 14 )
 
 [node name="HurtBox" parent="." index="5" groups=[
 "player",
-] instance=ExtResource( 14 )]
+] instance=ExtResource( 15 )]
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HurtBox" index="0"]
 position = Vector2( 0, -64 )
 shape = SubResource( 2 )
 
 [node name="PlayerStatus" type="Node" parent="." index="6"]
-script = ExtResource( 15 )
-player_data = ExtResource( 16 )
+script = ExtResource( 16 )
+player_data = ExtResource( 17 )
 
 [node name="PickupArea" type="Area2D" parent="." index="7"]
 collision_layer = 0
 collision_mask = 4
-script = ExtResource( 17 )
-player_data = ExtResource( 16 )
+script = ExtResource( 18 )
+player_data = ExtResource( 17 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PickupArea" index="0"]
 position = Vector2( 0, -64 )

--- a/source/actors/player/PlayerHoldAction.tscn
+++ b/source/actors/player/PlayerHoldAction.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://actors/player/PlayerAction.tscn" type="PackedScene" id=1]
+
+[node name="PlayerHoldAction" instance=ExtResource( 1 )]
+
+[node name="Threshold" type="Timer" parent="." index="0"]
+wait_time = 0.5
+one_shot = true
+[connection signal="pressed" from="." to="Threshold" method="start"]
+[connection signal="released" from="." to="Threshold" method="stop"]
+[connection signal="timeout" from="Threshold" to="." method="emit_signal" binds= [ "held" ]]

--- a/source/actors/player/buccerino/Buccerino.tscn
+++ b/source/actors/player/buccerino/Buccerino.tscn
@@ -1,18 +1,17 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=22 format=2]
 
 [ext_resource path="res://actors/player/PlayerCombatActor.tscn" type="PackedScene" id=1]
-[ext_resource path="res://actors/player/buccerino/HoldTimer.gd" type="Script" id=2]
-[ext_resource path="res://actors/combat/Combo.tscn" type="PackedScene" id=3]
-[ext_resource path="res://actors/combat/Attack.tscn" type="PackedScene" id=4]
-[ext_resource path="res://actors/combat/HitBox.tscn" type="PackedScene" id=5]
-[ext_resource path="res://actors/player/PlayerCutHit.tres" type="Resource" id=6]
-[ext_resource path="res://actors/player/PlayerSliceHit.tres" type="Resource" id=7]
-[ext_resource path="res://actors/player/PlayerDiceHit.tres" type="Resource" id=8]
-[ext_resource path="res://actors/player/PlayerChargeHit.tres" type="Resource" id=9]
-[ext_resource path="res://actors/physics/State.gd" type="Script" id=10]
-[ext_resource path="res://actors/player/PlayerSpinHit.tres" type="Resource" id=11]
-[ext_resource path="res://actors/player/buccerino/PigCharacter.tscn" type="PackedScene" id=12]
-[ext_resource path="res://utility/DebugPanel.tscn" type="PackedScene" id=13]
+[ext_resource path="res://actors/combat/Combo.tscn" type="PackedScene" id=2]
+[ext_resource path="res://actors/combat/Attack.tscn" type="PackedScene" id=3]
+[ext_resource path="res://actors/combat/HitBox.tscn" type="PackedScene" id=4]
+[ext_resource path="res://actors/player/PlayerCutHit.tres" type="Resource" id=5]
+[ext_resource path="res://actors/player/PlayerSliceHit.tres" type="Resource" id=6]
+[ext_resource path="res://actors/player/PlayerDiceHit.tres" type="Resource" id=7]
+[ext_resource path="res://actors/player/PlayerChargeHit.tres" type="Resource" id=8]
+[ext_resource path="res://actors/physics/State.gd" type="Script" id=9]
+[ext_resource path="res://actors/player/PlayerSpinHit.tres" type="Resource" id=10]
+[ext_resource path="res://actors/player/buccerino/PigCharacter.tscn" type="PackedScene" id=11]
+[ext_resource path="res://utility/DebugPanel.tscn" type="PackedScene" id=12]
 
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 48, 40 )
@@ -124,17 +123,19 @@ tracks/0/keys = {
 "update": 0,
 "values": [ 0.0, 1.0 ]
 }
-tracks/1/type = "value"
-tracks/1/path = NodePath("ChargeBar:visible")
+tracks/1/type = "method"
+tracks/1/path = NodePath("CombatStateMachine")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
 tracks/1/enabled = true
 tracks/1/keys = {
-"times": PoolRealArray( 0, 0.5 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ true, false ]
+"times": PoolRealArray( 0.5 ),
+"transitions": PoolRealArray( 1 ),
+"values": [ {
+"args": [ "Charge" ],
+"method": "execute"
+} ]
 }
 
 [sub_resource type="Animation" id=6]
@@ -504,83 +505,77 @@ actor_path = NodePath("../../../../Buccerino")
 [node name="DuckState" parent="StateMachine" index="10"]
 editor/display_folded = true
 
-[node name="HoldThreshold" type="Timer" parent="Controls/AttackAction" index="0"]
-wait_time = 0.5
-one_shot = true
-
-[node name="HoldTimer" type="Timer" parent="Controls/AttackAction" index="1"]
-wait_time = 0.5
-one_shot = true
-script = ExtResource( 2 )
+[node name="AttackHoldAction" parent="Controls" index="7"]
+action = "attack"
 
 [node name="CombatStateMachine" parent="." index="4"]
 actor_path = NodePath("../../Buccerino")
 
-[node name="Attack" parent="CombatStateMachine/IdleState" index="0" instance=ExtResource( 3 )]
-editor/display_folded = true
+[node name="Attack" parent="CombatStateMachine/IdleState" index="0" instance=ExtResource( 2 )]
 position = Vector2( 104, -64 )
 
-[node name="Cut" parent="CombatStateMachine/IdleState/Attack" index="0" instance=ExtResource( 4 )]
+[node name="Cut" parent="CombatStateMachine/IdleState/Attack" index="0" instance=ExtResource( 3 )]
 editor/display_folded = true
 
-[node name="HitBox" parent="CombatStateMachine/IdleState/Attack/Cut" index="1" instance=ExtResource( 5 )]
-hit = ExtResource( 6 )
+[node name="HitBox" parent="CombatStateMachine/IdleState/Attack/Cut" index="1" instance=ExtResource( 4 )]
+hit = ExtResource( 5 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CombatStateMachine/IdleState/Attack/Cut/HitBox" index="0"]
 shape = SubResource( 1 )
 disabled = true
 
-[node name="Slice" parent="CombatStateMachine/IdleState/Attack" index="1" instance=ExtResource( 4 )]
+[node name="Slice" parent="CombatStateMachine/IdleState/Attack" index="1" instance=ExtResource( 3 )]
+editor/display_folded = true
 
-[node name="HitBox" parent="CombatStateMachine/IdleState/Attack/Slice" index="1" instance=ExtResource( 5 )]
-hit = ExtResource( 7 )
+[node name="HitBox" parent="CombatStateMachine/IdleState/Attack/Slice" index="1" instance=ExtResource( 4 )]
+hit = ExtResource( 6 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CombatStateMachine/IdleState/Attack/Slice/HitBox" index="0"]
 shape = SubResource( 1 )
 
-[node name="Dice" parent="CombatStateMachine/IdleState/Attack" index="2" instance=ExtResource( 4 )]
+[node name="Dice" parent="CombatStateMachine/IdleState/Attack" index="2" instance=ExtResource( 3 )]
+editor/display_folded = true
 
-[node name="HitBox" parent="CombatStateMachine/IdleState/Attack/Dice" index="1" instance=ExtResource( 5 )]
-hit = ExtResource( 8 )
+[node name="HitBox" parent="CombatStateMachine/IdleState/Attack/Dice" index="1" instance=ExtResource( 4 )]
+hit = ExtResource( 7 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CombatStateMachine/IdleState/Attack/Dice/HitBox" index="0"]
 shape = SubResource( 1 )
 
-[node name="Charge" parent="CombatStateMachine/IdleState" index="1" instance=ExtResource( 4 )]
-editor/display_folded = true
+[node name="Charge" parent="CombatStateMachine/IdleState" index="1" instance=ExtResource( 3 )]
 position = Vector2( 103, -63 )
 
-[node name="HitBox" parent="CombatStateMachine/IdleState/Charge" index="1" instance=ExtResource( 5 )]
-hit = ExtResource( 9 )
+[node name="HitBox" parent="CombatStateMachine/IdleState/Charge" index="1" instance=ExtResource( 4 )]
+hit = ExtResource( 8 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CombatStateMachine/IdleState/Charge/HitBox" index="0"]
 shape = SubResource( 2 )
 disabled = true
 
-[node name="Charging" parent="CombatStateMachine/IdleState" index="2" instance=ExtResource( 4 )]
+[node name="Charging" parent="CombatStateMachine/IdleState" index="2" instance=ExtResource( 3 )]
 
 [node name="JumpState" type="Node2D" parent="CombatStateMachine" index="1"]
-script = ExtResource( 10 )
+script = ExtResource( 9 )
 
-[node name="Attack" parent="CombatStateMachine/JumpState" index="0" instance=ExtResource( 4 )]
+[node name="Attack" parent="CombatStateMachine/JumpState" index="0" instance=ExtResource( 3 )]
 editor/display_folded = true
 position = Vector2( 0, -64 )
 
-[node name="HitBox" parent="CombatStateMachine/JumpState/Attack" index="1" instance=ExtResource( 5 )]
-hit = ExtResource( 11 )
+[node name="HitBox" parent="CombatStateMachine/JumpState/Attack" index="1" instance=ExtResource( 4 )]
+hit = ExtResource( 10 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CombatStateMachine/JumpState/Attack/HitBox" index="0"]
 shape = SubResource( 3 )
 disabled = true
 
 [node name="SingleFallState" type="Node2D" parent="CombatStateMachine" index="2"]
-script = ExtResource( 10 )
+script = ExtResource( 9 )
 
 [node name="WalkState" type="Node2D" parent="CombatStateMachine" index="3"]
-script = ExtResource( 10 )
+script = ExtResource( 9 )
 
 [node name="DashState" type="Node2D" parent="CombatStateMachine" index="4"]
-script = ExtResource( 10 )
+script = ExtResource( 9 )
 
 [node name="HurtBox" parent="." index="5"]
 editor/display_folded = true
@@ -588,11 +583,11 @@ editor/display_folded = true
 [node name="PickupArea" parent="." index="7"]
 editor/display_folded = true
 
-[node name="Pig" parent="." index="8" instance=ExtResource( 12 )]
+[node name="Pig" parent="." index="8" instance=ExtResource( 11 )]
 
 [node name="Debug" type="CanvasLayer" parent="." index="9"]
 
-[node name="DebugPanel" parent="Debug" index="0" instance=ExtResource( 13 )]
+[node name="DebugPanel" parent="Debug" index="0" instance=ExtResource( 12 )]
 reference_path = NodePath("../../StateMachine")
 properties = PoolStringArray( "previous_state_name", "current_state_name" )
 
@@ -622,6 +617,8 @@ one_shot = true
 [connection signal="entered" from="StateMachine/WalkState" to="Pig" method="play" binds= [ "walk" ]]
 [connection signal="entered" from="StateMachine/JumpState" to="Pig" method="play" binds= [ "jump" ]]
 [connection signal="entered" from="StateMachine/DashState" to="Pig" method="play" binds= [ "dash" ]]
+[connection signal="started" from="StateMachine/DashState/Bump" to="StateMachine" method="change_state_to" binds= [ "DashFall" ]]
+[connection signal="started" from="StateMachine/DashState/DistanceStop" to="StateMachine" method="change_state_to" binds= [ "DashFall" ]]
 [connection signal="entered" from="StateMachine/DashJumpState" to="Pig" method="play" binds= [ "dash" ]]
 [connection signal="entered" from="StateMachine/SecondJumpState" to="Pig" method="play" binds= [ "jump" ]]
 [connection signal="entered" from="StateMachine/DashJumpFallState" to="Pig" method="play" binds= [ "fall" ]]
@@ -629,39 +626,41 @@ one_shot = true
 [connection signal="entered" from="StateMachine/DashFallState" to="Pig" method="play" binds= [ "fall" ]]
 [connection signal="entered" from="StateMachine/SecondFallState" to="Pig" method="play" binds= [ "fall" ]]
 [connection signal="entered" from="StateMachine/DuckState" to="Pig" method="play" binds= [ "duck" ]]
+[connection signal="pressed" from="Controls/LeftAction" to="CombatStateMachine" method="set_direction" binds= [ Vector2( -1, 0 ) ]]
 [connection signal="pressed" from="Controls/LeftAction" to="Pig" method="set_look_direction" binds= [ -1 ]]
+[connection signal="pressed" from="Controls/RightAction" to="CombatStateMachine" method="set_direction" binds= [ Vector2( 1, 0 ) ]]
 [connection signal="pressed" from="Controls/RightAction" to="Pig" method="set_look_direction" binds= [ 1 ]]
-[connection signal="pressed" from="Controls/AttackAction" to="Controls/AttackAction/HoldThreshold" method="start"]
-[connection signal="released" from="Controls/AttackAction" to="Controls/AttackAction/HoldThreshold" method="stop"]
-[connection signal="released" from="Controls/AttackAction" to="Controls/AttackAction/HoldTimer" method="stop"]
-[connection signal="timeout" from="Controls/AttackAction/HoldThreshold" to="Controls/AttackAction/HoldTimer" method="start"]
-[connection signal="timeout" from="Controls/AttackAction/HoldThreshold" to="CombatStateMachine" method="execute" binds= [ "Charging" ]]
-[connection signal="stopped" from="Controls/AttackAction/HoldTimer" to="CombatStateMachine" method="cancel" binds= [ "Charging" ]]
-[connection signal="timeout" from="Controls/AttackAction/HoldTimer" to="CombatStateMachine" method="execute" binds= [ "Charge" ]]
+[connection signal="pressed" from="Controls/DownAction" to="StateMachine" method="execute" binds= [ "Duck" ]]
+[connection signal="released" from="Controls/DownAction" to="StateMachine" method="execute" binds= [ "Stand" ]]
+[connection signal="held" from="Controls/AttackHoldAction" to="CombatStateMachine" method="execute" binds= [ "Charging" ]]
+[connection signal="released" from="Controls/AttackHoldAction" to="CombatStateMachine" method="cancel" binds= [ "Charging" ]]
 [connection signal="finished" from="CombatStateMachine/IdleState/Attack" to="ComboResetTime" method="start"]
-[connection signal="finished" from="CombatStateMachine/IdleState/Attack/Cut" to="AttackAnimator" method="stop"]
 [connection signal="finished" from="CombatStateMachine/IdleState/Attack/Cut" to="Pig" method="play" binds= [ "idle" ]]
-[connection signal="started" from="CombatStateMachine/IdleState/Attack/Cut" to="AttackAnimator" method="play" binds= [ "cut" ]]
+[connection signal="finished" from="CombatStateMachine/IdleState/Attack/Cut" to="AttackAnimator" method="stop"]
 [connection signal="started" from="CombatStateMachine/IdleState/Attack/Cut" to="Pig" method="play" binds= [ "cut" ]]
-[connection signal="finished" from="CombatStateMachine/IdleState/Attack/Slice" to="AttackAnimator" method="stop"]
+[connection signal="started" from="CombatStateMachine/IdleState/Attack/Cut" to="AttackAnimator" method="play" binds= [ "cut" ]]
 [connection signal="finished" from="CombatStateMachine/IdleState/Attack/Slice" to="Pig" method="play" binds= [ "idle" ]]
-[connection signal="started" from="CombatStateMachine/IdleState/Attack/Slice" to="AttackAnimator" method="play" binds= [ "slice" ]]
+[connection signal="finished" from="CombatStateMachine/IdleState/Attack/Slice" to="AttackAnimator" method="stop"]
 [connection signal="started" from="CombatStateMachine/IdleState/Attack/Slice" to="Pig" method="play" binds= [ "slice" ]]
-[connection signal="finished" from="CombatStateMachine/IdleState/Attack/Dice" to="AttackAnimator" method="stop"]
+[connection signal="started" from="CombatStateMachine/IdleState/Attack/Slice" to="AttackAnimator" method="play" binds= [ "slice" ]]
 [connection signal="finished" from="CombatStateMachine/IdleState/Attack/Dice" to="Pig" method="play" binds= [ "idle" ]]
-[connection signal="started" from="CombatStateMachine/IdleState/Attack/Dice" to="AttackAnimator" method="play" binds= [ "dice" ]]
+[connection signal="finished" from="CombatStateMachine/IdleState/Attack/Dice" to="AttackAnimator" method="stop"]
 [connection signal="started" from="CombatStateMachine/IdleState/Attack/Dice" to="Pig" method="play" binds= [ "dice" ]]
-[connection signal="finished" from="CombatStateMachine/IdleState/Charge" to="CombatStateMachine/IdleState/Charge/HitBox" method="disable"]
+[connection signal="started" from="CombatStateMachine/IdleState/Attack/Dice" to="AttackAnimator" method="play" binds= [ "dice" ]]
+[connection signal="finished" from="CombatStateMachine/IdleState/Charge" to="ChargeBar" method="hide"]
 [connection signal="finished" from="CombatStateMachine/IdleState/Charge" to="CombatStateMachine/IdleState/Charge/HitBox/CollisionShape2D" method="set_disabled" binds= [ true ]]
-[connection signal="started" from="CombatStateMachine/IdleState/Charge" to="AttackAnimator" method="play" binds= [ "charge" ]]
+[connection signal="finished" from="CombatStateMachine/IdleState/Charge" to="CombatStateMachine/IdleState/Charge/HitBox" method="disable"]
 [connection signal="started" from="CombatStateMachine/IdleState/Charge" to="Pig" method="play" binds= [ "charge" ]]
+[connection signal="started" from="CombatStateMachine/IdleState/Charge" to="AttackAnimator" method="play" binds= [ "charge" ]]
 [connection signal="finished" from="CombatStateMachine/IdleState/Charging" to="ChargeBar" method="set_value" binds= [ 0.0 ]]
 [connection signal="finished" from="CombatStateMachine/IdleState/Charging" to="ChargeBar" method="hide"]
-[connection signal="finished" from="CombatStateMachine/IdleState/Charging" to="CombatStateMachine" method="cancel" binds= [ "Charge" ]]
-[connection signal="started" from="CombatStateMachine/IdleState/Charging" to="AttackAnimator" method="play" binds= [ "charging" ]]
+[connection signal="finished" from="CombatStateMachine/IdleState/Charging" to="Pig" method="play" binds= [ "idle" ]]
+[connection signal="finished" from="CombatStateMachine/IdleState/Charging" to="AttackAnimator" method="stop"]
+[connection signal="started" from="CombatStateMachine/IdleState/Charging" to="ChargeBar" method="show"]
 [connection signal="started" from="CombatStateMachine/IdleState/Charging" to="Pig" method="play" binds= [ "charging" ]]
+[connection signal="started" from="CombatStateMachine/IdleState/Charging" to="AttackAnimator" method="play" binds= [ "charging" ]]
 [connection signal="finished" from="CombatStateMachine/JumpState/Attack" to="AttackAnimator" method="stop"]
-[connection signal="started" from="CombatStateMachine/JumpState/Attack" to="AttackAnimator" method="play" binds= [ "spin" ]]
 [connection signal="started" from="CombatStateMachine/JumpState/Attack" to="Pig" method="play" binds= [ "spin" ]]
+[connection signal="started" from="CombatStateMachine/JumpState/Attack" to="AttackAnimator" method="play" binds= [ "spin" ]]
 [connection signal="entered" from="CombatStateMachine/SingleFallState" to="CombatStateMachine" method="change_state_to" binds= [ "Jump" ]]
 [connection signal="timeout" from="ComboResetTime" to="CombatStateMachine/IdleState/Attack" method="reset"]

--- a/source/actors/player/buccerino/HoldTimer.gd
+++ b/source/actors/player/buccerino/HoldTimer.gd
@@ -1,7 +1,0 @@
-extends Timer
-
-signal stopped
-
-func stop():
-	emit_signal("stopped")
-	.stop()

--- a/source/levels/CombatPlayground.tscn
+++ b/source/levels/CombatPlayground.tscn
@@ -77,6 +77,7 @@ wait_time = 5.0
 one_shot = true
 
 [node name="CombatDummy" parent="." instance=ExtResource( 6 )]
+editor/display_folded = true
 position = Vector2( 940, 620 )
 
 [node name="CollisionShape2D" parent="CombatDummy" index="0"]
@@ -145,8 +146,8 @@ position = Vector2( 160, 464 )
 z_index = 1
 [connection signal="timeout" from="LeftMovingDummySpawner/Timer" to="LeftMovingDummySpawner" method="spawn"]
 [connection signal="timeout" from="LeftMovingDummySpawner/Timer" to="RightMovingDummySpawner/Timer" method="start"]
-[connection signal="timeout" from="RightMovingDummySpawner/Timer" to="LeftMovingDummySpawner/Timer" method="start"]
 [connection signal="timeout" from="RightMovingDummySpawner/Timer" to="RightMovingDummySpawner" method="spawn"]
+[connection signal="timeout" from="RightMovingDummySpawner/Timer" to="LeftMovingDummySpawner/Timer" method="start"]
 [connection signal="started" from="CombatDummy/StateMachine/IdleState/Move" to="CombatDummy/StateMachine" method="change_state_to" binds= [ "Walk" ]]
 [connection signal="started" from="CombatDummy/StateMachine/IdleState/Jump" to="CombatDummy/StateMachine" method="change_state_to" binds= [ "Jump" ]]
 [connection signal="started" from="CombatDummy/StateMachine/IdleState/Fall" to="CombatDummy/StateMachine" method="change_state_to" binds= [ "SingleJumpFall" ]]


### PR DESCRIPTION
Previously there was a messy connection between the AttackAction and the HoldThreshold and HoldTimer nodes. This is gone, now there is a HoldAction node which uses a threshold to notify if the given action was held for a given amount of time.